### PR TITLE
Fix ARM support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -79,7 +79,7 @@ class LZMAConan(ConanFile):
                 args.extend(['--enable-static', '--disable-shared'])
             if self.settings.build_type == 'Debug':
                 args.append('--enable-debug')
-            env_build.configure(args=args)
+            env_build.configure(args=args, build=False)
             env_build.make()
             env_build.make(args=['install'])
 


### PR DESCRIPTION
Related issue: https://github.com/bincrafters/community/issues/197

When build on ARM platform, Conan fills `build=None-arm-linux`, resulting in error.

I tested this change over my OrangePi (armv7l) and cross-building on lasote/conangcc6-armv7.